### PR TITLE
Fix schedule page: remove old dividers + fix widget rendering

### DIFF
--- a/source/contact.blade.php
+++ b/source/contact.blade.php
@@ -42,6 +42,18 @@ description: Get in touch to discuss your technology and security leadership nee
                     </div>
                 </div>
 
+                {{-- Book directly --}}
+                <div class="bg-crimson-900/20 border border-crimson-800/40 rounded-xl p-6 mb-8">
+                    <h3 class="font-display text-lg font-bold text-white mb-2">Prefer to just book?</h3>
+                    <p class="text-echo-400 mb-4">Skip the form and grab a 30-minute strategy session directly on my calendar.</p>
+                    <a href="/schedule" class="inline-flex items-center gap-2 px-5 py-3 bg-crimson-600 hover:bg-crimson-500 text-white font-semibold rounded-lg transition-colors">
+                        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+                        </svg>
+                        Schedule a Strategy Session
+                    </a>
+                </div>
+
                 {{-- Direct contact info --}}
                 <div class="bg-echo-800/30 border border-echo-700 rounded-xl p-6 space-y-4">
                     <h3 class="font-display text-lg font-bold text-white mb-4">Direct contact</h3>

--- a/source/schedule.blade.php
+++ b/source/schedule.blade.php
@@ -5,27 +5,13 @@ description: This page contains the scheduling widget.
 @extends('_layouts.main')
 
 @section('body')
-    <div class="bg-gray-900 py-16">
-        <div class="mx-auto max-w-7xl">
+    <div class="py-16">
+        <div class="mx-auto max-w-7xl px-4">
             <iframe src="https://apicrm.ctox.com/widget/booking/zAqfOrmeZgIyao4KAxMq"
-                style="width: 100%;border:none;overflow: hidden;" scrolling="no"
-                id="zAqfOrmeZgIyao4KAxMq_1774581419819"></iframe><br>
+                style="width: 100%; min-height: 700px; border: none; overflow: hidden;" scrolling="no"
+                id="zAqfOrmeZgIyao4KAxMq_1774581419819"></iframe>
             <script src="https://apicrm.ctox.com/js/form_embed.js" type="text/javascript"></script>
-            <!-- Custom HR -->
-            <div class="flex items-center">
-                <div class="h-0.5 bg-crimson-900 flex-1"></div>
-                <div class="h-2 w-2 bg-crimson-900 rounded-full mr-4"></div>
-                <div class="h-2 w-2 bg-crimson-900 rounded-full"></div>
-                <div class="h-0.5 bg-crimson-900 flex-1"></div>
-            </div>
-            <div class="flex items-center my-2">
-                <div class="h-0.5 bg-gray-700 flex-1"></div>
-                <div class="h-0.5 bg-gray-700 flex-1"></div>
-                <div class="h-2 w-2 bg-gray-700 rounded-full mr-4"></div>
-                <div class="h-2 w-2 bg-gray-700 rounded-full"></div>
-                <div class="h-0.5 bg-gray-700 flex-1"></div>
-            </div>
-            <div class="bg-white rounded-lg mt-8">
+            <div class="bg-white rounded-lg mt-12">
                 <div class="mx-auto max-w-7xl px-6 py-24 sm:pt-32 lg:px-8 lg:py-40">
                     <div class="lg:grid lg:grid-cols-12 lg:gap-8">
                         <div class="lg:col-span-5">

--- a/source/schedule.blade.php
+++ b/source/schedule.blade.php
@@ -1,54 +1,56 @@
 ---
-title: Scheduling page
-description: This page contains the scheduling widget.
+title: Strategy Session
+description: Book a free strategy session with Mike Faas to discuss your business, technology, and security.
 ---
 @extends('_layouts.main')
 
 @section('body')
-    <div class="py-16">
-        <div class="mx-auto max-w-7xl px-4">
+    <section class="py-16 lg:py-24">
+        <div class="mx-auto max-w-4xl px-4">
+            {{-- Calendar Widget --}}
             <iframe src="https://apicrm.ctox.com/widget/booking/zAqfOrmeZgIyao4KAxMq"
-                style="width: 100%; min-height: 700px; border: none; overflow: hidden;" scrolling="no"
-                id="zAqfOrmeZgIyao4KAxMq_1774581419819"></iframe>
+                style="width: 100%; min-height: 800px; border: none; overflow: hidden;" scrolling="no"
+                id="zAqfOrmeZgIyao4KAxMq_1774581419819"
+                allow="payment"></iframe>
             <script src="https://apicrm.ctox.com/js/form_embed.js" type="text/javascript"></script>
-            <div class="bg-white rounded-lg mt-12">
-                <div class="mx-auto max-w-7xl px-6 py-24 sm:pt-32 lg:px-8 lg:py-40">
-                    <div class="lg:grid lg:grid-cols-12 lg:gap-8">
-                        <div class="lg:col-span-5">
-                            <h2 class="text-2xl font-bold leading-10 tracking-tight text-gray-900">Frequently asked
-                                questions</h2>
-                            <p class="mt-4 text-base leading-7 text-gray-600">Can't find the answer you're looking for?
-                                <a href="/contact"
-                                    class="font-semibold text-crimson-600 hover:text-crimson-500">Get in touch</a>.</p>
+        </div>
+    </section>
+
+    {{-- FAQ Section --}}
+    <section class="py-16 lg:py-24 bg-echo-900/50">
+        <div class="mx-auto max-w-7xl px-6 lg:px-8">
+            <div class="lg:grid lg:grid-cols-12 lg:gap-8">
+                <div class="lg:col-span-5">
+                    <h2 class="text-2xl font-bold leading-10 tracking-tight text-echo-100">Frequently asked
+                        questions</h2>
+                    <p class="mt-4 text-base leading-7 text-echo-400">Can't find the answer you're looking for?
+                        <a href="/contact"
+                            class="font-semibold text-crimson-500 hover:text-crimson-400">Get in touch</a>.</p>
+                </div>
+                <div class="mt-10 lg:col-span-7 lg:mt-0">
+                    <dl class="space-y-10">
+                        <div>
+                            <dt class="text-base font-semibold leading-7 text-echo-100">What will we cover in the
+                                strategy session?</dt>
+                            <dd class="mt-2 text-base leading-7 text-echo-400">You'll talk directly with me about where your business is today &mdash; your team size, how you use technology, and what's keeping you up at night. This isn't a deep-dive audit. It's a conversation to figure out if there's a fit. If there is, we'll talk about what comes next. If there isn't, you'll still walk away with something useful.</dd>
                         </div>
-                        <div class="mt-10 lg:col-span-7 lg:mt-0">
-                            <dl class="space-y-10">
-                                <div>
-                                    <dt class="text-base font-semibold leading-7 text-gray-900">What will we cover in the
-                                        strategy session?</dt>
-                                    <dd class="mt-2 text-base leading-7 text-gray-600">You'll talk directly with me about where your business is today &mdash; your team size, how you use technology, and what's keeping you up at night. This isn't a deep-dive audit. It's a conversation to figure out if there's a fit. If there is, we'll talk about what comes next. If there isn't, you'll still walk away with something useful.</dd>
-                                </div>
-                                <div>
-                                    <dt class="text-base font-semibold leading-7 text-gray-900">Is there a cost for this
-                                        initial session?</dt>
-                                    <dd class="mt-2 text-base leading-7 text-gray-600">No. Zero. This is a conversation, not a sales pitch.</dd>
-                                </div>
-                                <div>
-                                    <dt class="text-base font-semibold leading-7 text-gray-900">Who will I be meeting with?
-                                    </dt>
-                                    <dd class="mt-2 text-base leading-7 text-gray-600">Me &mdash; Mike Faas. I'm a fractional CTO and CISO who helps founder-led businesses make sense of technology and security without the overhead of a full-time executive. I've led security programs for companies like Carhartt, Bose, and Black Rifle Coffee Company.</dd>
-                                </div>
-                                <div>
-                                    <dt class="text-base font-semibold leading-7 text-gray-900">What should I prepare for
-                                        the meeting?
-                                    </dt>
-                                    <dd class="mt-2 text-base leading-7 text-gray-600">Nothing formal. Know your business, know what's bugging you. That's enough.</dd>
-                                </div>
-                            </dl>
+                        <div>
+                            <dt class="text-base font-semibold leading-7 text-echo-100">Is there a cost for this
+                                initial session?</dt>
+                            <dd class="mt-2 text-base leading-7 text-echo-400">No. Zero. This is a conversation, not a sales pitch.</dd>
                         </div>
-                    </div>
+                        <div>
+                            <dt class="text-base font-semibold leading-7 text-echo-100">Who will I be meeting with?</dt>
+                            <dd class="mt-2 text-base leading-7 text-echo-400">Me &mdash; Mike Faas. I'm a fractional CTO and CISO who helps founder-led businesses make sense of technology and security without the overhead of a full-time executive. I've led security programs for companies like Carhartt, Bose, and Black Rifle Coffee Company.</dd>
+                        </div>
+                        <div>
+                            <dt class="text-base font-semibold leading-7 text-echo-100">What should I prepare for
+                                the meeting?</dt>
+                            <dd class="mt-2 text-base leading-7 text-echo-400">Nothing formal. Know your business, know what's bugging you. That's enough.</dd>
+                        </div>
+                    </dl>
                 </div>
             </div>
         </div>
-    </div>
+    </section>
 @stop

--- a/source/schedule.blade.php
+++ b/source/schedule.blade.php
@@ -5,7 +5,7 @@ description: Book a free strategy session with Mike Faas to discuss your busines
 @extends('_layouts.main')
 
 @section('body')
-    <section class="pt-4 pb-16 lg:pt-6 lg:pb-24">
+    <section class="pb-16 lg:pb-24">
         <div class="mx-auto max-w-7xl px-4">
             {{-- Calendar Widget --}}
             <iframe src="https://apicrm.ctox.com/widget/booking/KjGTZUQdoqLZpU5NtmNL"

--- a/source/schedule.blade.php
+++ b/source/schedule.blade.php
@@ -5,13 +5,15 @@ description: Book a free strategy session with Mike Faas to discuss your busines
 @extends('_layouts.main')
 
 @section('body')
-    <section class="py-16 lg:py-24">
+    <section class="pt-4 pb-16 lg:pt-6 lg:pb-24">
         <div class="mx-auto max-w-7xl px-4">
             {{-- Calendar Widget --}}
-            <iframe src="https://apicrm.ctox.com/widget/booking/KjGTZUQdoqLZpU5NtmNL"
-                style="width: 100%; min-height: 800px; border: none; overflow: hidden;" scrolling="no"
-                id="KjGTZUQdoqLZpU5NtmNL_1774582373290"
-                allow="payment"></iframe>
+            <div class="bg-echo-800/30 border border-echo-700 rounded-xl overflow-hidden">
+                <iframe src="https://apicrm.ctox.com/widget/booking/KjGTZUQdoqLZpU5NtmNL"
+                    style="width: 100%; min-height: 800px; border: none; overflow: hidden;" scrolling="no"
+                    id="KjGTZUQdoqLZpU5NtmNL_1774582373290"
+                    allow="payment"></iframe>
+            </div>
             <script src="https://apicrm.ctox.com/js/form_embed.js" type="text/javascript"></script>
         </div>
     </section>

--- a/source/schedule.blade.php
+++ b/source/schedule.blade.php
@@ -8,12 +8,10 @@ description: Book a free strategy session with Mike Faas to discuss your busines
     <section class="pt-4 pb-16 lg:pt-6 lg:pb-24">
         <div class="mx-auto max-w-7xl px-4">
             {{-- Calendar Widget --}}
-            <div class="bg-echo-800/30 border border-echo-700 rounded-xl overflow-hidden">
-                <iframe src="https://apicrm.ctox.com/widget/booking/KjGTZUQdoqLZpU5NtmNL"
-                    style="width: 100%; min-height: 800px; border: none; overflow: hidden;" scrolling="no"
-                    id="KjGTZUQdoqLZpU5NtmNL_1774582373290"
-                    allow="payment"></iframe>
-            </div>
+            <iframe src="https://apicrm.ctox.com/widget/booking/KjGTZUQdoqLZpU5NtmNL"
+                style="width: 100%; min-height: 800px; border: none; overflow: hidden;" scrolling="no"
+                id="KjGTZUQdoqLZpU5NtmNL_1774582373290"
+                allow="payment"></iframe>
             <script src="https://apicrm.ctox.com/js/form_embed.js" type="text/javascript"></script>
         </div>
     </section>

--- a/source/schedule.blade.php
+++ b/source/schedule.blade.php
@@ -6,7 +6,7 @@ description: Book a free strategy session with Mike Faas to discuss your busines
 
 @section('body')
     <section class="py-16 lg:py-24">
-        <div class="mx-auto max-w-4xl px-4">
+        <div class="mx-auto max-w-7xl px-4">
             {{-- Calendar Widget --}}
             <iframe src="https://apicrm.ctox.com/widget/booking/KjGTZUQdoqLZpU5NtmNL"
                 style="width: 100%; min-height: 800px; border: none; overflow: hidden;" scrolling="no"

--- a/source/schedule.blade.php
+++ b/source/schedule.blade.php
@@ -8,9 +8,9 @@ description: Book a free strategy session with Mike Faas to discuss your busines
     <section class="py-16 lg:py-24">
         <div class="mx-auto max-w-4xl px-4">
             {{-- Calendar Widget --}}
-            <iframe src="https://apicrm.ctox.com/widget/booking/zAqfOrmeZgIyao4KAxMq"
+            <iframe src="https://apicrm.ctox.com/widget/booking/KjGTZUQdoqLZpU5NtmNL"
                 style="width: 100%; min-height: 800px; border: none; overflow: hidden;" scrolling="no"
-                id="zAqfOrmeZgIyao4KAxMq_1774581419819"
+                id="KjGTZUQdoqLZpU5NtmNL_1774582373290"
                 allow="payment"></iframe>
             <script src="https://apicrm.ctox.com/js/form_embed.js" type="text/javascript"></script>
         </div>


### PR DESCRIPTION
Follow-up to #75.

- Removed old crimson/gray decorative dividers
- Removed dark bg-gray-900 background (was hiding the widget)
- Added min-height: 700px so the iframe renders properly
- Added px-4 padding for mobile
- Cleaned up stray br tag