### PR TITLE
Defend newsletter signup form against subscription-bombing

### DIFF
--- a/config.php
+++ b/config.php
@@ -5,6 +5,7 @@ use Illuminate\Support\Str;
 return [
     'baseUrl' => '',
     'production' => false,
+    'turnstileSiteKey' => getenv('TURNSTILE_SITE_KEY') ?: '',
     'siteName' => 'Echo Cyber',
     'siteDescription' => 'Fractional CTO & CISO services for growing businesses.',
     'siteAuthor' => 'Michael Faas',

--- a/config.production.php
+++ b/config.production.php
@@ -3,4 +3,5 @@
 return [
     'baseUrl' => 'https://echocyber.io',
     'production' => true,
+    'turnstileSiteKey' => getenv('TURNSTILE_SITE_KEY') ?: '',
 ];

--- a/netlify/functions/subscribe.mjs
+++ b/netlify/functions/subscribe.mjs
@@ -1,22 +1,68 @@
 // Netlify Function: Newsletter subscription
-// Accepts { email, source? }, subscribes to Beehiiv, returns ok/error.
+// Accepts { email, source?, hp?, ts?, turnstileToken? }, runs anti-spam checks,
+// subscribes to Beehiiv on success.
 
 const BEEHIIV_API_KEY = process.env.BEEHIIV_API_KEY;
 const BEEHIIV_PUB_ID = process.env.BEEHIIV_PUB_ID || 'pub_4aa9e626-adfb-44d3-991a-ba8cbdd146fa';
+const TURNSTILE_SECRET = process.env.TURNSTILE_SECRET_KEY;
 
-const submissions = new Map();
-const RATE_LIMIT = 5;
-const RATE_WINDOW_MS = 30 * 60 * 1000;
+const MIN_FILL_TIME_MS = 2000;
 
-function isRateLimited(ip) {
+// Canonical-email dedupe within a sliding window. In-memory per Lambda instance —
+// not bulletproof on serverless cold starts, but combined with Turnstile + honeypot
+// is sufficient to defeat the dot-trick burst pattern we're seeing.
+const recentCanonicals = new Map();
+const CANON_WINDOW_MS = 60 * 60 * 1000;
+
+// Per-IP throttle as defense in depth.
+const ipSubmissions = new Map();
+const IP_LIMIT = 5;
+const IP_WINDOW_MS = 30 * 60 * 1000;
+
+function canonicalizeEmail(email) {
+  const lower = email.toLowerCase();
+  const at = lower.indexOf('@');
+  if (at < 1) return lower;
+  let local = lower.slice(0, at);
+  let domain = lower.slice(at + 1);
+  if (domain === 'googlemail.com') domain = 'gmail.com';
+  local = local.split('+')[0];
+  if (domain === 'gmail.com') local = local.replace(/\./g, '');
+  return `${local}@${domain}`;
+}
+
+function isIpThrottled(ip) {
   const now = Date.now();
-  const record = submissions.get(ip);
-  if (!record || now - record.firstAt > RATE_WINDOW_MS) {
-    submissions.set(ip, { count: 1, firstAt: now });
+  const record = ipSubmissions.get(ip);
+  if (!record || now - record.firstAt > IP_WINDOW_MS) {
+    ipSubmissions.set(ip, { count: 1, firstAt: now });
     return false;
   }
   record.count++;
-  return record.count > RATE_LIMIT;
+  return record.count > IP_LIMIT;
+}
+
+function sweepCanonicals() {
+  const now = Date.now();
+  for (const [k, v] of recentCanonicals) {
+    if (now - v > CANON_WINDOW_MS) recentCanonicals.delete(k);
+  }
+}
+
+async function verifyTurnstile(token, ip) {
+  if (!TURNSTILE_SECRET) return { ok: true, skipped: true };
+  if (!token) return { ok: false, reason: 'missing-token' };
+  try {
+    const res = await fetch('https://challenges.cloudflare.com/turnstile/v0/siteverify', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({ secret: TURNSTILE_SECRET, response: token, remoteip: ip }),
+    });
+    const data = await res.json();
+    return { ok: !!data.success, reason: (data['error-codes'] || []).join(',') };
+  } catch (err) {
+    return { ok: false, reason: `fetch-error: ${err.message}` };
+  }
 }
 
 export default async (req, context) => {
@@ -33,18 +79,50 @@ export default async (req, context) => {
   }
 
   const ip = context.ip || req.headers.get('x-forwarded-for') || 'unknown';
-  if (isRateLimited(ip)) {
-    return new Response(JSON.stringify({ error: 'Too many submissions' }), { status: 429, headers });
-  }
 
   let data;
   try { data = await req.json(); }
   catch { return new Response(JSON.stringify({ error: 'Invalid JSON' }), { status: 400, headers }); }
 
-  const { email, source } = data;
+  const { email, source, hp, ts, turnstileToken } = data;
+
+  // Honeypot — bots fill, humans never see. Pretend success so bots don't learn.
+  if (hp) {
+    console.warn(`[subscribe] honeypot tripped (ip=${ip})`);
+    return new Response(JSON.stringify({ ok: true }), { status: 200, headers });
+  }
+
+  // Min-form-fill time — humans take >2s to type an email; instant POSTs are scripts.
+  if (typeof ts === 'number') {
+    const elapsed = Date.now() - ts;
+    if (elapsed < MIN_FILL_TIME_MS) {
+      console.warn(`[subscribe] too-fast submission (${elapsed}ms, ip=${ip})`);
+      return new Response(JSON.stringify({ ok: true }), { status: 200, headers });
+    }
+  }
+
   if (!email || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
     return new Response(JSON.stringify({ error: 'Valid email required' }), { status: 400, headers });
   }
+
+  if (isIpThrottled(ip)) {
+    return new Response(JSON.stringify({ error: 'Too many submissions' }), { status: 429, headers });
+  }
+
+  const turnstile = await verifyTurnstile(turnstileToken, ip);
+  if (!turnstile.ok) {
+    console.warn(`[subscribe] turnstile failed (ip=${ip}, reason=${turnstile.reason})`);
+    return new Response(JSON.stringify({ error: 'Verification failed. Please try again.' }), { status: 403, headers });
+  }
+
+  // Canonical-email dedupe — defeats Gmail dot-trick + plus-tag list-bombing.
+  sweepCanonicals();
+  const canonical = canonicalizeEmail(email);
+  if (recentCanonicals.has(canonical)) {
+    console.warn(`[subscribe] duplicate canonical (canonical=${canonical}, raw=${email}, ip=${ip})`);
+    return new Response(JSON.stringify({ ok: true }), { status: 200, headers });
+  }
+  recentCanonicals.set(canonical, Date.now());
 
   if (!BEEHIIV_API_KEY) {
     console.error('[subscribe] BEEHIIV_API_KEY not configured');
@@ -76,7 +154,8 @@ export default async (req, context) => {
       return new Response(JSON.stringify({ error: 'Subscription failed' }), { status: 502, headers });
     }
 
-    console.log(`[subscribe] ${email} subscribed (source: ${source || 'homepage'})`);
+    const turnstileNote = turnstile.skipped ? ' [turnstile-skipped]' : '';
+    console.log(`[subscribe] ${email} subscribed (canonical=${canonical}, source=${source || 'homepage'})${turnstileNote}`);
     return new Response(JSON.stringify({ ok: true }), { status: 200, headers });
   } catch (err) {
     console.error(`[subscribe] fetch error: ${err.message}`);

--- a/source/_partials/home/newsletter.blade.php
+++ b/source/_partials/home/newsletter.blade.php
@@ -15,7 +15,7 @@
             </p>
         </div>
 
-        <div x-data="newsletterSignup()" class="mx-auto mt-10 max-w-lg">
+        <div x-data="newsletterSignup()" x-init="init()" class="mx-auto mt-10 max-w-lg">
             <form @submit.prevent="submit()" x-show="!success" class="flex flex-col gap-3 sm:flex-row">
                 <label for="newsletter-email" class="sr-only">Email address</label>
                 <input id="newsletter-email" type="email" x-model="email" required
@@ -26,7 +26,25 @@
                         class="px-6 py-3 bg-crimson-700 hover:bg-crimson-600 disabled:opacity-60 disabled:cursor-not-allowed text-white font-semibold rounded-lg transition-all hover:shadow-glow whitespace-nowrap">
                     <span x-text="submitting ? 'Subscribing...' : 'Subscribe'"></span>
                 </button>
+
+                {{-- Honeypot: invisible to humans, irresistible to lazy bots. --}}
+                <input type="text" name="company_website" x-model="hp" tabindex="-1" autocomplete="off"
+                       aria-hidden="true"
+                       style="position:absolute;left:-5000px;width:1px;height:1px;opacity:0">
             </form>
+
+            {{-- Cloudflare Turnstile widget. Renders nothing when site key is unset. --}}
+            @if (!empty($page->turnstileSiteKey))
+            <div x-show="!success" class="mt-3 flex justify-center">
+                <div class="cf-turnstile"
+                     data-sitekey="{{ $page->turnstileSiteKey }}"
+                     data-callback="onTurnstileSuccess"
+                     data-error-callback="onTurnstileError"
+                     data-expired-callback="onTurnstileExpired"
+                     data-theme="dark"
+                     data-size="flexible"></div>
+            </div>
+            @endif
 
             <div x-show="success" x-cloak x-transition class="rounded-lg border border-crimson-800/50 bg-crimson-950/30 p-4 text-center">
                 <p class="font-semibold text-white">You're in. 💎</p>
@@ -44,14 +62,30 @@
     </div>
 </section>
 
+@if (!empty($page->turnstileSiteKey))
+@push('scripts')
+<script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>
+@endpush
+@endif
+
 @push('scripts')
 <script>
 function newsletterSignup() {
     return {
         email: '',
+        hp: '',
+        ts: 0,
+        turnstileToken: '',
         submitting: false,
         success: false,
         error: '',
+        init() {
+            this.ts = Date.now();
+            // Expose token-setter callbacks for Turnstile.
+            window.onTurnstileSuccess = (token) => { this.turnstileToken = token; };
+            window.onTurnstileError = () => { this.turnstileToken = ''; };
+            window.onTurnstileExpired = () => { this.turnstileToken = ''; };
+        },
         async submit() {
             if (this.submitting) return;
             this.submitting = true;
@@ -60,13 +94,23 @@ function newsletterSignup() {
                 const res = await fetch('/.netlify/functions/subscribe', {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ email: this.email, source: 'homepage' }),
+                    body: JSON.stringify({
+                        email: this.email,
+                        source: 'homepage',
+                        hp: this.hp,
+                        ts: this.ts,
+                        turnstileToken: this.turnstileToken,
+                    }),
                 });
                 const data = await res.json().catch(() => ({}));
                 if (res.ok && data.ok) {
                     this.success = true;
                 } else {
                     this.error = data.error || 'Something went wrong. Try again?';
+                    // Reset Turnstile so user can retry.
+                    if (window.turnstile && typeof window.turnstile.reset === 'function') {
+                        window.turnstile.reset();
+                    }
                 }
             } catch (err) {
                 this.error = 'Network error. Try again?';


### PR DESCRIPTION
## Summary

The newsletter signup endpoint had effectively no anti-spam protection. A subscription-bombing attack started on **Apr 23**, weaponizing the form against third-party Gmail/Yahoo recipients via the Gmail dot-randomization trick (`da.v.idd.u.b.a.rj.r@gmail.com` → `daviddubarjr@gmail.com`). 13+ obvious dot-bombed addresses are already on the active list as of today (May 1).

This PR adds layered defenses, all **invisible to legitimate users** — single-opt-in is preserved, no DOI added, no friction.

## Defenses added

| Defense | What it catches |
|---|---|
| **Cloudflare Turnstile** (server-verified) | Bots that can't pass a browser-fingerprint challenge. Single biggest lever. |
| **Gmail/plus-tag canonicalization** | The exact dot-trick attack we're seeing. `john.smith+x@googlemail.com` → `johnsmith@gmail.com`. Re-submissions of the same canonical dropped silently. |
| **Honeypot field** | Lazy bots that fill every input they find. Off-screen, irresistibly named (`company_website`). |
| **Min-form-fill time** (2s) | Scripts that POST instantly without rendering the page. |
| **Per-IP throttle** (kept) | Defense in depth. Still in-memory; should be replaced with Cloudflare WAF rate-limit at the edge later. |

The broken in-memory rate limit (5/30min) wasn't actually doing anything on serverless cold starts — it's still there but is now backup, not primary defense.

## Required setup before this PR fully activates

The PR is **safe to merge before configuring Turnstile** — the function gracefully skips Turnstile verification when `TURNSTILE_SECRET_KEY` is unset, and the Turnstile widget renders nothing when `TURNSTILE_SITE_KEY` is empty. Honeypot, time check, and Gmail canonicalization activate immediately on merge.

To turn on Turnstile after merge:

1. **Cloudflare dashboard → Turnstile → Add site**
   - Domain: `echocyber.io`
   - Widget mode: **Managed** (default)
   - Save → copy site key and secret key
2. **Netlify → Site settings → Environment variables** → add:
   - `TURNSTILE_SITE_KEY` = the public site key
   - `TURNSTILE_SECRET_KEY` = the secret key
3. Trigger a new Netlify deploy (env-var change alone won't rebuild Jigsaw — needs a clear cache & redeploy, or a no-op commit).

Once both env vars are set and a fresh build deploys, Turnstile activates automatically.

## Pre-merge cleanup (separate from this PR)

The bombed addresses already on the active list will receive Sunday's Pulse if not removed. Recommend pruning before then. I can pull a classified list (`definitely bombed / probably bombed / probably real`) and either bulk-delete via the Beehiiv API or hand it to you for manual cleanup in the Beehiiv dashboard.

## Test plan

- [ ] Netlify preview deploy builds clean
- [ ] Subscribe with a real email on the preview → succeeds, lands in Beehiiv with `utm_source=homepage`
- [ ] Open DevTools, submit empty `email` → 400 with `Valid email required`
- [ ] DevTools, manually fill `company_website` honeypot before submit → response is 200 ok but `subscribe` log shows `honeypot tripped`, no Beehiiv call
- [ ] DevTools, submit within <2s of page load → response is 200 ok but log shows `too-fast submission`
- [ ] Submit `t.e.s.t@gmail.com` then `test@gmail.com` from same Lambda warm instance → second is silently dropped (`duplicate canonical`)
- [ ] After Turnstile env vars set + redeploy: widget appears under form, valid submission works, dropping the token via DevTools triggers 403 `Verification failed`
- [ ] Production: confirm widget is invisible/unobtrusive on real signups, log shows `[turnstile-skipped]` is gone

## Files changed

- `netlify/functions/subscribe.mjs` — anti-spam pipeline rewrite
- `source/_partials/home/newsletter.blade.php` — Turnstile widget, honeypot, timestamp, Alpine wiring
- `config.php` / `config.production.php` — expose `TURNSTILE_SITE_KEY` env var to Jigsaw build