### PR TITLE
Hardcode Turnstile site key — env var not reaching Jigsaw build

### DIFF
--- a/config.production.php
+++ b/config.production.php
@@ -3,5 +3,8 @@
 return [
     'baseUrl' => 'https://echocyber.io',
     'production' => true,
-    'turnstileSiteKey' => getenv('TURNSTILE_SITE_KEY') ?: '',
+    // Turnstile site key is public (gets rendered into HTML). Hardcoded
+    // because Jigsaw's PHP child process doesn't reliably see Netlify env
+    // vars at build time. The matching SECRET key stays in Netlify env.
+    'turnstileSiteKey' => '0x4AAAAAADG_poOR76T-jTV5',
 ];


### PR DESCRIPTION
## Why

After merging #87, the Turnstile widget never rendered on the live site. Diagnosis:

- ✅ Env vars are set in Netlify with all scopes (`builds, functions, post_processing, runtime`)
- ✅ Latest production deploy (commit \`70d205d4\`) succeeded
- ❌ The newsletter section in the rendered HTML has the conditional block evaluating empty:

  ```html
  <input ... name="company_website" ...>   <!-- honeypot: present ✓ -->
  </form>
              
              
  <div x-show="success" ...>               <!-- ← Turnstile div should be here -->
  ```

The `@if (!empty($page->turnstileSiteKey))` block is rendering as blank lines, meaning `getenv('TURNSTILE_SITE_KEY')` returned empty during the Jigsaw build despite the env var being set with `builds` scope.

Most likely cause: PHP's `variables_order` config on Netlify's PHP image, or the way `@tighten/jigsaw-vite-plugin` spawns the Jigsaw subprocess, isn't propagating env vars to PHP. Not worth chasing.

## Fix

Hardcode the site key in `config.production.php`. The site key is **public by design** — it gets baked into the page HTML so the browser can call Cloudflare's challenges API. There's no security benefit to env-loading it, only added complexity.

The **secret key** (which actually matters) stays in Netlify env (`TURNSTILE_SECRET_KEY`) and is consumed only by `subscribe.mjs` at function-runtime, which has no env propagation issues.

## Test plan

- [ ] Preview deploy renders the Turnstile widget on the homepage newsletter form
- [ ] Production deploy after merge: `curl -s https://echocyber.io/ | grep -c cf-turnstile` returns ≥1
- [ ] Subscribe flow works end-to-end with Turnstile rendering