### PR TITLE
Inline Turnstile site key directly in blade

### DIFF
--- a/source/_partials/home/newsletter.blade.php
+++ b/source/_partials/home/newsletter.blade.php
@@ -33,18 +33,16 @@
                        style="position:absolute;left:-5000px;width:1px;height:1px;opacity:0">
             </form>
 
-            {{-- Cloudflare Turnstile widget. Renders nothing when site key is unset. --}}
-            @if (!empty($page->turnstileSiteKey))
+            {{-- Cloudflare Turnstile widget. Site key is public; matching secret stays in Netlify env. --}}
             <div x-show="!success" class="mt-3 flex justify-center">
                 <div class="cf-turnstile"
-                     data-sitekey="{{ $page->turnstileSiteKey }}"
+                     data-sitekey="0x4AAAAAADG_poOR76T-jTV5"
                      data-callback="onTurnstileSuccess"
                      data-error-callback="onTurnstileError"
                      data-expired-callback="onTurnstileExpired"
                      data-theme="dark"
                      data-size="flexible"></div>
             </div>
-            @endif
 
             <div x-show="success" x-cloak x-transition class="rounded-lg border border-crimson-800/50 bg-crimson-950/30 p-4 text-center">
                 <p class="font-semibold text-white">You're in. 💎</p>
@@ -62,11 +60,9 @@
     </div>
 </section>
 
-@if (!empty($page->turnstileSiteKey))
 @push('scripts')
 <script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>
 @endpush
-@endif
 
 @push('scripts')
 <script>


### PR DESCRIPTION
## Why

After merging #88, Turnstile still didn't render. The hardcoded value in \`config.production.php\` doesn't reach \`\$page->turnstileSiteKey\` in the blade template, despite \`\$page->production\` and \`\$page->baseUrl\` (defined in the same file) working correctly.

I don't have a great explanation for why this specific key wasn't propagating. Either Jigsaw's config merge is doing something unexpected with this key name, or there's some build cache I haven't pinned down. Both options for digging further (run a local Jigsaw build, instrument the bootstrap) are time sinks I don't want to take on before Sunday's newsletter.

## Fix

Drop the indirection. Inline the site key directly in the blade template and remove both \`@if (!empty(\$page->turnstileSiteKey))\` guards. The widget now always renders.

The site key is public — it's designed to land in HTML for the browser to call Cloudflare's challenges API. Inlining it has no security cost and removes a layer that's not pulling its weight.

## Test plan

- [ ] Preview deploy: \`curl https://deploy-preview-89--echocyberio.netlify.app/ | grep cf-turnstile\` returns a hit
- [ ] After merge: \`curl https://echocyber.io/ | grep -c cf-turnstile\` returns ≥1
- [ ] Visit homepage in browser: Turnstile widget appears below the email/subscribe row, dark theme, no challenge for typical visitors
- [ ] Submit valid email → succeeds (Beehiiv subscription created with utm_source=homepage)
- [ ] Open DevTools, drop the turnstileToken, submit → server returns 403 \"Verification failed\"