### PR TITLE
Add /measure short-URL redirect to Signal Measure pilot page

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -14,3 +14,8 @@ timeout = 26
   to = "https://pod.link/1894903133"
   status = 301
   force = true
+
+[[redirects]]
+  from = "/measure"
+  to = "/sprint/measure"
+  status = 301


### PR DESCRIPTION
Adds a speakable short URL `echocyber.io/measure` that 301-redirects to the canonical `/sprint/measure` pilot page. For verbal/podcast CTAs and easier sharing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)